### PR TITLE
outString is not working correctly.

### DIFF
--- a/BareMetal_examples/build_bare_metal_zcu102/hello_world.c
+++ b/BareMetal_examples/build_bare_metal_zcu102/hello_world.c
@@ -91,8 +91,9 @@ void outString(char* string){
     if(NULL == string)
         return;
 
-    while(0 != *(string++)){
+    while(0 != *string){
         outByte(*string);
+        string++;
     }
 }
 


### PR DESCRIPTION
When I run bare metal application example (https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/821854273/Running+Bare+Metal+Applications+on+QEMU), I got "ello World on Xilinx's QEMU for ZCU102" instead of "Hello World on Xilinx's QEMU for ZCU102".

It always skips the first character, because outString function increments the string pointer before transmitting the first character.

This change will fix this problem.